### PR TITLE
ci: add fail under flag to coverage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ match-dir = (?!migrations)
 
 [pytest]
 DJANGO_SETTINGS_MODULE = openedx_events_2_zapier.settings.test
-addopts = --cov openedx_events_2_zapier --cov-report term-missing --cov-report xml
+addopts = --cov openedx_events_2_zapier --cov-report term-missing --cov-report xml --cov-fail-under 90
 norecursedirs = .* docs requirements site-packages
 
 [testenv]


### PR DESCRIPTION
**Description:** 
This PR adds a coverage baseline for failure.

https://github.com/eduNEXT/openedx-events-2-zapier/pull/2/checks?check_run_id=3746827147#step:6:47