### PR TITLE
refactor: [FC-0074] drop support for python 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Framework :: Django",
-        "Framework :: Django :: 2.2",
+        "Framework :: Django :: 4.2",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
         "Natural Language :: English",

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=load_requirements("requirements/base.in"),
-    python_requires=">=3.8",
+    python_requires=">=3.11",
     license="AGPL 3.0",
     zip_safe=False,
     keywords="Python edx",
@@ -93,7 +93,7 @@ setup(
         "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.11",
     ],
     entry_points={
         "lms.djangoapp": [


### PR DESCRIPTION
### Description

This PR explicitly drops support for python 3.8 in favor of python 3.11.